### PR TITLE
fixed shader include path problem

### DIFF
--- a/App/MainApp.cpp
+++ b/App/MainApp.cpp
@@ -39,8 +39,8 @@ void MainApp::Start()
 {
     Devices::Get()->GetWindow()->SetTitle("MapleLeaf");
     // Graphics::Get()->SetRenderer(std::make_unique<MainRenderer>());
-    Graphics::Get()->SetRenderer(std::make_unique<GPURenderer>());
-    // Graphics::Get()->SetRenderer(std::make_unique<StereoRenderer>());
+    // Graphics::Get()->SetRenderer(std::make_unique<GPURenderer>());
+    Graphics::Get()->SetRenderer(std::make_unique<StereoRenderer>());
 
 
     std::unique_ptr<SceneBuilder> scene = std::make_unique<SceneBuilder>();

--- a/Core/GPUScene/GPUScene.hpp
+++ b/Core/GPUScene/GPUScene.hpp
@@ -34,8 +34,6 @@ public:
 
     uint32_t GetInstanceCount() const { return instances.size(); }
 
-    // static std::unique_ptr<IndirectBuffer> ComputeFrustumCulling(const StorageBuffer* instanceBuffer);
-
 private:
     struct InstanceData
     {

--- a/Core/Graphics/Resources/Buffer.cpp
+++ b/Core/Graphics/Resources/Buffer.cpp
@@ -98,7 +98,7 @@ void Buffer::InsertBufferMemoryBarrier(const CommandBuffer& commandBuffer, const
                                        VkDeviceSize offset, VkDeviceSize size)
 {
     VkBufferMemoryBarrier bufferMemoryBarrier = {};
-    bufferMemoryBarrier.sType                 = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    bufferMemoryBarrier.sType                 = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
     bufferMemoryBarrier.srcAccessMask         = srcAccessMask;
     bufferMemoryBarrier.dstAccessMask         = dstAccessMask;
     bufferMemoryBarrier.srcQueueFamilyIndex   = VK_QUEUE_FAMILY_IGNORED;

--- a/Core/Graphics/Resources/IndirectBuffer.cpp
+++ b/Core/Graphics/Resources/IndirectBuffer.cpp
@@ -38,6 +38,16 @@ WriteDescriptorSet IndirectBuffer::GetWriteDescriptor(uint32_t binding, VkDescri
     return {descriptorWrite, bufferInfo};
 }
 
+void IndirectBuffer::IndirectBufferPipelineBarrier(const CommandBuffer& commandBuffer) const
+{
+    Buffer::InsertBufferMemoryBarrier(commandBuffer,
+                                      this->buffer,
+                                      VK_ACCESS_SHADER_WRITE_BIT,
+                                      VK_ACCESS_INDIRECT_COMMAND_READ_BIT,
+                                      VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                                      VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT);
+}
+
 VkDescriptorSetLayoutBinding IndirectBuffer::GetDescriptorSetLayout(uint32_t binding, VkDescriptorType descriptorType, VkShaderStageFlags stage,
                                                                     uint32_t count)
 {

--- a/Core/Graphics/Resources/IndirectBuffer.hpp
+++ b/Core/Graphics/Resources/IndirectBuffer.hpp
@@ -14,6 +14,8 @@ public:
     WriteDescriptorSet GetWriteDescriptor(uint32_t binding, VkDescriptorType descriptorType,
                                           const std::optional<OffsetSize>& offsetSize) const override;
 
+    void IndirectBufferPipelineBarrier(const CommandBuffer& commandBuffer) const;
+
     static VkDescriptorSetLayoutBinding GetDescriptorSetLayout(uint32_t binding, VkDescriptorType descriptorType, VkShaderStageFlags stage,
                                                                uint32_t count);
 };

--- a/Core/Scenes/Camera.cpp
+++ b/Core/Scenes/Camera.cpp
@@ -32,23 +32,8 @@ void Camera::Update()
         UpdateByInput();
     }
 
-    viewMatrix       = glm::lookAt(position, position + forward, up);
-    projectionMatrix = glm::perspective(fieldOfView, aspectRatio, nearPlane, farPlane);
-
-    invViewMatrix       = glm::inverse(viewMatrix);
-    invProjectionMatrix = glm::inverse(projectionMatrix);
-
-    stereoViewPosition[0] = glm::vec4(position - right * eyeSeparation / 2.0f, 1.0f);
-    stereoViewPosition[1] = glm::vec4(position + right * eyeSeparation / 2.0f, 1.0f);
-
-    stereoViewMatrix[0]          = glm::lookAt(glm::vec3(stereoViewPosition[0]), glm::vec3(stereoViewPosition[0]) + forward, up);
-    stereoViewMatrix[1]          = glm::lookAt(glm::vec3(stereoViewPosition[1]), glm::vec3(stereoViewPosition[1]) + forward, up);
-    stereoProjectionMatrix[0]    = glm::perspective(fieldOfView, aspectRatio / 2, nearPlane, farPlane);
-    stereoProjectionMatrix[1]    = glm::perspective(fieldOfView, aspectRatio / 2, nearPlane, farPlane);
-    invStereoViewMatrix[0]       = glm::inverse(stereoViewMatrix[0]);
-    invStereoViewMatrix[1]       = glm::inverse(stereoViewMatrix[1]);
-    invStereoProjectionMatrix[0] = glm::inverse(stereoProjectionMatrix[0]);
-    invStereoProjectionMatrix[1] = glm::inverse(stereoProjectionMatrix[1]);
+    UpdateCameraInfo();
+    UpdateStereoCameraInfo();
 }
 
 void Camera::UpdateByTransform()
@@ -95,6 +80,96 @@ void Camera::UpdateByInput()
     }
 }
 
+void Camera::UpdateCameraInfo()
+{
+    viewMatrix       = glm::lookAt(position, position + forward, up);
+    projectionMatrix = glm::perspective(fieldOfView, aspectRatio, nearPlane, farPlane);
+
+    invViewMatrix       = glm::inverse(viewMatrix);
+    invProjectionMatrix = glm::inverse(projectionMatrix);
+
+    glm::vec3 farPlaneCenter       = position + forward * farPlane;
+    glm::vec3 nearPlaneCenter      = position + forward * nearPlane;
+    float     farPlaneHalfVertical = farPlane * std::tan(fieldOfView / 2.0f);
+    float     farPlaneHalfHorizon  = farPlaneHalfVertical * aspectRatio;
+
+    glm::vec3 leftTop     = glm::vec3(farPlaneCenter.x - farPlaneHalfHorizon, farPlaneCenter.y + farPlaneHalfVertical, farPlaneCenter.z);
+    glm::vec3 rightTop    = glm::vec3(farPlaneCenter.x + farPlaneHalfHorizon, farPlaneCenter.y + farPlaneHalfVertical, farPlaneCenter.z);
+    glm::vec3 leftBottom  = glm::vec3(farPlaneCenter.x - farPlaneHalfHorizon, farPlaneCenter.y - farPlaneHalfVertical, farPlaneCenter.z);
+    glm::vec3 rightBottom = glm::vec3(farPlaneCenter.x + farPlaneHalfHorizon, farPlaneCenter.y - farPlaneHalfVertical, farPlaneCenter.z);
+
+    frustumVector[0] = glm::normalize(glm::vec4(leftTop - position, 0.0f));
+    frustumVector[1] = glm::normalize(glm::vec4(rightTop - position, 0.0f));
+    frustumVector[2] = glm::normalize(glm::vec4(leftBottom - position, 0.0f));
+    frustumVector[3] = glm::normalize(glm::vec4(rightBottom - position, 0.0f));
+
+    frustumPlane[0] = glm::vec4(glm::normalize(glm::cross(glm::vec3(frustumVector[2]), glm::vec3(frustumVector[0]))), 0.0f);
+    frustumPlane[1] = glm::vec4(glm::normalize(glm::cross(glm::vec3(frustumVector[1]), glm::vec3(frustumVector[3]))), 0.0f);
+    frustumPlane[2] = glm::vec4(glm::normalize(glm::cross(glm::vec3(frustumVector[3]), glm::vec3(frustumVector[2]))), 0.0f);
+    frustumPlane[3] = glm::vec4(glm::normalize(glm::cross(glm::vec3(frustumVector[0]), glm::vec3(frustumVector[1]))), 0.0f);
+    frustumPlane[4] = glm::vec4(forward, 0.0f);
+    frustumPlane[5] = glm::vec4(-forward, 0.0f);
+
+    frustumPlane[0].w = -glm::dot(glm::vec3(frustumPlane[0]), position);
+    frustumPlane[1].w = -glm::dot(glm::vec3(frustumPlane[1]), position);
+    frustumPlane[2].w = -glm::dot(glm::vec3(frustumPlane[2]), position);
+    frustumPlane[3].w = -glm::dot(glm::vec3(frustumPlane[3]), position);
+    frustumPlane[4].w = -glm::dot(glm::vec3(frustumPlane[4]), nearPlaneCenter);
+    frustumPlane[5].w = -glm::dot(glm::vec3(frustumPlane[5]), farPlaneCenter);
+}
+
+void Camera::UpdateStereoCameraInfo()
+{
+    stereoViewPosition[0] = glm::vec4(position - right * eyeSeparation / 2.0f, 1.0f);
+    stereoViewPosition[1] = glm::vec4(position + right * eyeSeparation / 2.0f, 1.0f);
+
+    stereoViewMatrix[0]       = glm::lookAt(glm::vec3(stereoViewPosition[0]), glm::vec3(stereoViewPosition[0]) + forward, up);
+    stereoViewMatrix[1]       = glm::lookAt(glm::vec3(stereoViewPosition[1]), glm::vec3(stereoViewPosition[1]) + forward, up);
+    stereoProjectionMatrix[0] = glm::perspective(fieldOfView, aspectRatio / 2, nearPlane, farPlane);
+    stereoProjectionMatrix[1] = glm::perspective(fieldOfView, aspectRatio / 2, nearPlane, farPlane);
+
+    invStereoViewMatrix[0]       = glm::inverse(stereoViewMatrix[0]);
+    invStereoViewMatrix[1]       = glm::inverse(stereoViewMatrix[1]);
+    invStereoProjectionMatrix[0] = glm::inverse(stereoProjectionMatrix[0]);
+    invStereoProjectionMatrix[1] = glm::inverse(stereoProjectionMatrix[1]);
+
+    float farPlaneHalfVertical = farPlane * std::tan(fieldOfView / 2.0f);
+    float farPlaneHalfHorizon  = farPlaneHalfVertical * aspectRatio / 2.0f;
+
+    for (int i = 0; i <= 1; i++) {
+        const glm::vec3& curEyePosition  = glm::vec3(stereoViewPosition[i]);
+        glm::vec3        farPlaneCenter  = curEyePosition + forward * farPlane;
+        glm::vec3        nearPlaneCenter = curEyePosition + forward * nearPlane;
+
+        glm::vec3 leftTop     = glm::vec3(farPlaneCenter.x - farPlaneHalfHorizon, farPlaneCenter.y + farPlaneHalfVertical, farPlaneCenter.z);
+        glm::vec3 rightTop    = glm::vec3(farPlaneCenter.x + farPlaneHalfHorizon, farPlaneCenter.y + farPlaneHalfVertical, farPlaneCenter.z);
+        glm::vec3 leftBottom  = glm::vec3(farPlaneCenter.x - farPlaneHalfHorizon, farPlaneCenter.y - farPlaneHalfVertical, farPlaneCenter.z);
+        glm::vec3 rightBottom = glm::vec3(farPlaneCenter.x + farPlaneHalfHorizon, farPlaneCenter.y - farPlaneHalfVertical, farPlaneCenter.z);
+
+        stereoFrustumVector[i][0] = glm::normalize(glm::vec4(leftTop - curEyePosition, 0.0f));
+        stereoFrustumVector[i][1] = glm::normalize(glm::vec4(rightTop - curEyePosition, 0.0f));
+        stereoFrustumVector[i][2] = glm::normalize(glm::vec4(leftBottom - curEyePosition, 0.0f));
+        stereoFrustumVector[i][3] = glm::normalize(glm::vec4(rightBottom - curEyePosition, 0.0f));
+
+        stereoFrustumPlane[i][0] =
+            glm::vec4(glm::normalize(glm::cross(glm::vec3(stereoFrustumVector[i][2]), glm::vec3(stereoFrustumVector[i][0]))), 0.0f);
+        stereoFrustumPlane[i][1] =
+            glm::vec4(glm::normalize(glm::cross(glm::vec3(stereoFrustumVector[i][1]), glm::vec3(stereoFrustumVector[i][3]))), 0.0f);
+        stereoFrustumPlane[i][2] =
+            glm::vec4(glm::normalize(glm::cross(glm::vec3(stereoFrustumVector[i][3]), glm::vec3(stereoFrustumVector[i][2]))), 0.0f);
+        stereoFrustumPlane[i][3] =
+            glm::vec4(glm::normalize(glm::cross(glm::vec3(stereoFrustumVector[i][0]), glm::vec3(stereoFrustumVector[i][1]))), 0.0f);
+        stereoFrustumPlane[i][4] = glm::vec4(forward, 0.0f);
+        stereoFrustumPlane[i][5] = glm::vec4(-forward, 0.0f);
+
+        stereoFrustumPlane[i][0].w = -glm::dot(glm::vec3(stereoFrustumPlane[i][0]), curEyePosition);
+        stereoFrustumPlane[i][1].w = -glm::dot(glm::vec3(stereoFrustumPlane[i][1]), curEyePosition);
+        stereoFrustumPlane[i][2].w = -glm::dot(glm::vec3(stereoFrustumPlane[i][2]), curEyePosition);
+        stereoFrustumPlane[i][3].w = -glm::dot(glm::vec3(stereoFrustumPlane[i][3]), curEyePosition);
+        stereoFrustumPlane[i][4].w = -glm::dot(glm::vec3(stereoFrustumPlane[i][4]), nearPlaneCenter);
+        stereoFrustumPlane[i][5].w = -glm::dot(glm::vec3(stereoFrustumPlane[i][5]), farPlaneCenter);
+    }
+}
 
 const glm::vec4 Camera::GetZBufferParams() const
 {
@@ -125,5 +200,27 @@ const uint32_t Camera::GetStereoPixelWidth() const
 const glm::vec4 Camera::GetStereoPixelSize() const
 {
     return glm::vec4(GetStereoPixelWidth(), GetStereoPixelHeight(), 1.0f / GetStereoPixelWidth(), 1.0f / GetStereoPixelHeight());
+}
+
+void Camera::PushUniforms(UniformHandler& uniformObject)
+{
+    uniformObject.Push("projection", projectionMatrix);
+    uniformObject.Push("view", viewMatrix);
+    uniformObject.Push("invProjection", invProjectionMatrix);
+    uniformObject.Push("invView", invViewMatrix);
+    uniformObject.Push("stereoProjection", stereoProjectionMatrix);
+    uniformObject.Push("stereoView", stereoViewMatrix);
+    uniformObject.Push("invStereoProjection", invStereoProjectionMatrix);
+    uniformObject.Push("invStereoView", invStereoViewMatrix);
+    uniformObject.Push("frustumVector", frustumVector);
+    uniformObject.Push("frustumPlane", frustumPlane);
+    uniformObject.Push("stereoLeftFrustumVector", stereoFrustumVector[0]);
+    uniformObject.Push("stereoRightFrustumVector", stereoFrustumVector[1]);
+    uniformObject.Push("stereoLeftFrustumPlane", stereoFrustumPlane[0]);
+    uniformObject.Push("stereoRightFrustumPlane", stereoFrustumPlane[1]);
+    uniformObject.Push("zBufferParams", GetZBufferParams());
+    uniformObject.Push("pixelSize", GetPixelSize());
+    uniformObject.Push("cameraPosition", glm::vec4(position, 1.0f));
+    uniformObject.Push("cameraStereoPosition", stereoViewPosition);
 }
 }   // namespace MapleLeaf

--- a/Core/Scenes/Camera.hpp
+++ b/Core/Scenes/Camera.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Component.hpp"
+#include "DescriptorHandler.hpp"
 #include "glm/glm.hpp"
 #include "glm/gtc/matrix_transform.hpp"
 #include <array>
@@ -19,6 +20,11 @@ public:
 
     void UpdateByTransform();
     void UpdateByInput();
+
+    void UpdateCameraInfo();
+    void UpdateStereoCameraInfo();
+
+    void PushUniforms(UniformHandler& uniformObject);
 
     /**
      * Gets the distance of the near pane of the view frustum.
@@ -107,11 +113,25 @@ protected:
     glm::mat4 invViewMatrix;
     glm::mat4 invProjectionMatrix;
 
+    /* frustum's four vector, start from camera position
+     *0    1
+     *2    3
+     */
+    std::array<glm::vec4, 4> frustumVector;
+
+    /* frustum's six plane, store normal
+     * left, right, bottom, top, near, far
+     */
+    std::array<glm::vec4, 6> frustumPlane;
+
     std::array<glm::vec4, 2> stereoViewPosition;
 
     std::array<glm::mat4, 2> stereoViewMatrix;
     std::array<glm::mat4, 2> stereoProjectionMatrix;
     std::array<glm::mat4, 2> invStereoViewMatrix;
     std::array<glm::mat4, 2> invStereoProjectionMatrix;
+
+    std::array<std::array<glm::vec4, 4>, 2> stereoFrustumVector;
+    std::array<std::array<glm::vec4, 6>, 2> stereoFrustumPlane;
 };
 }   // namespace MapleLeaf

--- a/RenderPass/AO/HBAOSubrender.cpp
+++ b/RenderPass/AO/HBAOSubrender.cpp
@@ -31,7 +31,7 @@ void HBAOSubrender::Render(const CommandBuffer& commandBuffer)
     uniformScene.Push("zBufferParams", camera->GetZBufferParams());
     uniformScene.Push("pixelSize", camera->GetPixelSize());
 
-    float pixelRadius = camera->GetPixelHeight() * hbaoData.sampleRadius / (2.0f * glm::tan(camera->GetFieldOfView()));
+    float pixelRadius = camera->GetPixelHeight() * hbaoData.sampleRadius / (2.0f * glm::tan(camera->GetFieldOfView() / 2.0f));
 
     uniformHBAOData.Push("noiseScale", hbaoData.noiseScale);
     uniformHBAOData.Push("numRays", hbaoData.numRays);

--- a/RenderPass/IndirectDraw/IndirectDrawStereoSubrender.cpp
+++ b/RenderPass/IndirectDraw/IndirectDrawStereoSubrender.cpp
@@ -5,11 +5,37 @@
 namespace MapleLeaf {
 IndirectDrawStereoSubrender::IndirectDrawStereoSubrender(const Pipeline::Stage& pipelineStage)
     : Subrender(pipelineStage)
+    , compute("Shader/GPUDriven/CullingStereo.comp")
     , pipeline(pipelineStage, {"Shader/GPUDriven/DefaultStereo.vert", "Shader/GPUDriven/Multiview.geom", "Shader/GPUDriven/DefaultStereo.frag"},
                {Vertex3D::GetVertexInput()}, {}, PipelineGraphics::Mode::StereoMRT)
 {}
 
-void IndirectDrawStereoSubrender::PreRender(const CommandBuffer& commandBuffer) {}
+void IndirectDrawStereoSubrender::PreRender(const CommandBuffer& commandBuffer)
+{
+    const auto gpuScene = Scenes::Get()->GetScene()->GetGpuScene();
+    if (!gpuScene) return;
+    if (!gpuScene->GetIndirectBuffer()) return;
+
+    auto camera = Scenes::Get()->GetScene()->GetCamera();
+    camera->PushUniforms(uniformCameraCompute);
+
+    uint32_t instanceCount = gpuScene->GetInstanceCount();
+
+    pushHandler.Push("instanceCount", instanceCount);
+
+    descriptorSetCompute.Push("InstanceDatas", gpuScene->GetInstanceDatasHandler());
+    descriptorSetCompute.Push("DrawCommandBuffer", gpuScene->GetIndirectBuffer());
+    descriptorSetCompute.Push("UniformCamera", uniformCameraCompute);
+    descriptorSetCompute.Push("PushObject", pushHandler);
+
+    if (!descriptorSetCompute.Update(compute)) return;
+    compute.BindPipeline(commandBuffer);
+    descriptorSetCompute.BindDescriptor(commandBuffer, compute);
+    pushHandler.BindPush(commandBuffer, compute);
+    compute.CmdRender(commandBuffer, glm::uvec2(instanceCount, 1));
+
+    gpuScene->GetIndirectBuffer()->IndirectBufferPipelineBarrier(commandBuffer);
+}
 
 void IndirectDrawStereoSubrender::Render(const CommandBuffer& commandBuffer)
 {
@@ -17,17 +43,15 @@ void IndirectDrawStereoSubrender::Render(const CommandBuffer& commandBuffer)
     if (!gpuScene) return;
 
     auto camera = Scenes::Get()->GetScene()->GetCamera();
-    uniformScene.Push("projection", camera->GetStereoProjectionMatrix());
-    uniformScene.Push("view", camera->GetStereoViewMatrix());
-    uniformScene.Push("cameraPos", camera->GetPosition());
+    camera->PushUniforms(uniformCamera);
 
-    descriptorSet.Push("UniformScene", uniformScene);
-    gpuScene->PushDescriptors(descriptorSet);
+    descriptorSetGraphics.Push("UniformCamera", uniformCamera);
+    gpuScene->PushDescriptors(descriptorSetGraphics);
 
-    if (!descriptorSet.Update(pipeline)) return;
+    if (!descriptorSetGraphics.Update(pipeline)) return;
     pipeline.BindPipeline(commandBuffer);
 
-    descriptorSet.BindDescriptor(commandBuffer, pipeline);
+    descriptorSetGraphics.BindDescriptor(commandBuffer, pipeline);
 
     gpuScene->cmdRender(commandBuffer);
 }

--- a/RenderPass/IndirectDraw/IndirectDrawStereoSubrender.hpp
+++ b/RenderPass/IndirectDraw/IndirectDrawStereoSubrender.hpp
@@ -20,9 +20,14 @@ public:
     void PostRender(const CommandBuffer& commandBuffer) override;
 
 private:
-    PipelineGraphics   pipeline;
-    DescriptorsHandler descriptorSet;
+    PipelineGraphics pipeline;
+    PipelineCompute  compute;
 
-    UniformHandler uniformScene;
+    DescriptorsHandler descriptorSetCompute;
+    DescriptorsHandler descriptorSetGraphics;
+
+    PushHandler    pushHandler;
+    UniformHandler uniformCamera;
+    UniformHandler uniformCameraCompute;
 };
 }   // namespace MapleLeaf

--- a/RenderPass/IndirectDraw/IndirectDrawSubrender.cpp
+++ b/RenderPass/IndirectDraw/IndirectDrawSubrender.cpp
@@ -45,15 +45,7 @@ void IndirectDrawSubrender::PreRender(const CommandBuffer& commandBuffer)
     pushHandler.BindPush(commandBuffer, compute);
     compute.CmdRender(commandBuffer, glm::uvec2(instanceCount, 1));
 
-    VkBufferMemoryBarrier imageMemoryBarrier = {};
-    imageMemoryBarrier.sType                 = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
-    imageMemoryBarrier.srcAccessMask         = VK_ACCESS_SHADER_WRITE_BIT;
-    imageMemoryBarrier.dstAccessMask         = VK_ACCESS_INDIRECT_COMMAND_READ_BIT;
-    imageMemoryBarrier.buffer                = gpuScene->GetIndirectBuffer()->GetBuffer();
-    imageMemoryBarrier.offset                = 0;
-    imageMemoryBarrier.size                  = VK_WHOLE_SIZE;
-    vkCmdPipelineBarrier(
-        commandBuffer, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT, 0, 0, nullptr, 1, &imageMemoryBarrier, 0, nullptr);
+    gpuScene->GetIndirectBuffer()->IndirectBufferPipelineBarrier(commandBuffer);
 }
 
 void IndirectDrawSubrender::Render(const CommandBuffer& commandBuffer)

--- a/Resources/Shader/GPUDriven/CullingStereo.comp
+++ b/Resources/Shader/GPUDriven/CullingStereo.comp
@@ -1,0 +1,82 @@
+#version 460
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_ARB_shading_language_420pack : enable
+#extension GL_GOOGLE_include_directive : require
+
+layout(local_size_x = 32, local_size_y = 1, local_size_z = 1) in;
+
+#include <Misc/Camera.glsl>
+
+struct IndirectCommand {
+    uint indexCount;
+    uint instanceCount;
+    uint firstIndex;
+    int  vertexOffset;
+    uint firstInstance;
+};
+
+
+layout(set = 0, binding = 1) buffer DrawCommandBuffer 
+{
+    IndirectCommand commands[];
+} drawCommandBuffer;
+
+struct GPUInstanceData
+{
+    mat4 modelMatrix;
+    vec3 AABBLocalMin;
+    uint indexCount;
+    vec3 AABBLocalMax;
+    uint indexOffset;
+    uint vertexCount;
+    uint vertexOffset;
+    uint instanceID;
+    uint materialID;
+};
+
+layout(set = 0, binding = 2) buffer InstanceDatas
+{
+    GPUInstanceData instanceData[];
+} instanceDatas;
+
+layout(push_constant) uniform PushObject {
+	uint instanceCount;
+} object;
+
+bool CulledByFrustum(GPUInstanceData inst, int viewIndex) {
+    vec4[6] frustumPlane = GetFrustumPlanes(viewIndex);
+    mat4 M = inst.modelMatrix;
+    for (int j = 0; j < 6; j++) {
+        bool culled = true;
+        vec4 plane = frustumPlane[j];
+        for (int i = 0; i < 8; i++) {
+            vec3 w = vec3(i & 1, (i >> 1) & 1, (i >> 2) & 1);
+            vec4 p = M * vec4(mix(inst.AABBLocalMin, inst.AABBLocalMax, w), 1.0f);
+
+            culled = culled && dot(plane, p) < 0.0f;
+        }
+        if (culled) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool IsVisible(GPUInstanceData inst) {
+    return !CulledByFrustum(inst, 0) || !CulledByFrustum(inst, 1);
+}
+
+void main() {
+    int idx = int(gl_GlobalInvocationID.x);
+    if (idx >= int(object.instanceCount)) return;
+
+    GPUInstanceData instance = instanceDatas.instanceData[idx];
+    IndirectCommand cmd;
+    cmd.indexCount = instance.indexCount;
+    cmd.instanceCount = IsVisible(instance) ? 1 : 0;
+    cmd.firstIndex = instance.indexOffset;
+    cmd.vertexOffset = int(instance.vertexOffset);
+    cmd.firstInstance = instance.instanceID;
+
+    drawCommandBuffer.commands[idx] = cmd;
+}

--- a/Resources/Shader/GPUDriven/Multiview.geom
+++ b/Resources/Shader/GPUDriven/Multiview.geom
@@ -1,15 +1,12 @@
 #version 450
 
 #extension GL_ARB_viewport_array : enable
+#extension GL_GOOGLE_include_directive : require
 
 layout (triangles, invocations = 2) in;
 layout (triangle_strip, max_vertices = 3) out;
 
-layout (set = 0, binding = 0) uniform UniformScene{
-    mat4 projection[2];
-    mat4 view[2];
-    vec3 cameraPos;
-} scene;
+#include <Misc/Camera.glsl>
 
 layout(location = 0) in vec3 inPosition[];
 layout(location = 1) in vec2 inUV[];
@@ -31,7 +28,7 @@ void main()
         outMaterialId = inMaterialId[i];
 
         vec4 worldPosition = gl_in[i].gl_Position;
-        gl_Position = scene.projection[gl_InvocationID] * scene.view[gl_InvocationID] * worldPosition;
+        gl_Position = camera.stereoProjection[gl_InvocationID] * camera.stereoView[gl_InvocationID] * worldPosition;
 
         gl_ViewportIndex = gl_InvocationID;
         EmitVertex();

--- a/Resources/Shader/Misc/Camera.glsl
+++ b/Resources/Shader/Misc/Camera.glsl
@@ -1,24 +1,42 @@
+#ifndef MISC_CAMERA_GLSL
+#define MISC_CAMERA_GLSL
+
 layout(set=0, binding=0) uniform UniformCamera
 {
-	mat4  projection;
-	mat4  view;
-    mat4  invProjection;
-    mat4  invView;
-    mat4  stereoProjection[2];
-    mat4  stereoView[2];
-    mat4  invStereoProjection[2];
-    mat4  invStereoView[2];
-    vec4  zBufferParams; // x = 1-far/near, y = far/near,  z = x/far, w = y/far
-    vec4  pixelSize; // camera's pixelWidth, pixelHeight, 1.0 / pixelWidth, 1.0f / pixelHeight
-	vec4  cameraPosition;
-} scene;
+	mat4 projection;
+	mat4 view;
+    mat4 invProjection;
+    mat4 invView;
+    mat4 stereoProjection[2];
+    mat4 stereoView[2];
+    mat4 invStereoProjection[2];
+    mat4 invStereoView[2];
+    vec4 frustumVector[4]; // leftTop, rightTop, leftBottom, rightBottom
+    vec4 frustumPlane[6]; // left, right, bottom, top, near, far  normal(xyz)--d (ax+by+cz+d = 0)
+    vec4 stereoLeftFrustumVector[4];
+    vec4 stereoRightFrustumVector[4];
+    vec4 stereoLeftFrustumPlane[6];
+    vec4 stereoRightFrustumPlane[6];
+    vec4 zBufferParams; // x = 1-far/near, y = far/near,  z = x/far, w = y/far
+    vec4 pixelSize; // camera's pixelWidth, pixelHeight, 1.0 / pixelWidth, 1.0f / pixelHeight
+    vec4 cameraPosition;
+    vec4 cameraStereoPosition[2];
+} camera;
 
-float Linear01Depth(float z)
-{
-    return 1.0 / (scene.zBufferParams.x * z + scene.zBufferParams.y);
+vec4[6] GetFrustumPlanes(int viewIndex) {
+    return viewIndex == 0 ? camera.stereoLeftFrustumPlane : camera.stereoRightFrustumPlane;
 }
 
-float LinearEyeDepth(float z)
-{
-    return 1.0 / (scene.zBufferParams.z * z + scene.zBufferParams.w);
+vec4 GetCameraPosition(int viewIndex) {
+    return camera.cameraStereoPosition[viewIndex];
 }
+
+float Linear01Depth(float z) {
+    return 1.0 / (camera.zBufferParams.x * z + camera.zBufferParams.y);
+}
+
+float LinearEyeDepth(float z) {
+    return 1.0 / (camera.zBufferParams.z * z + camera.zBufferParams.w);
+}
+
+#endif

--- a/Resources/Shader/Misc/Constants.glsl
+++ b/Resources/Shader/Misc/Constants.glsl
@@ -3,6 +3,7 @@
 
 #undef M_PI
 #define M_PI 3.1415926535897932384626433832795
-#define INV_M_PI (1.0 / PI)
+#undef M_PI
+#define INV_M_PI (1.0 / M_PI)
 
 #endif


### PR DESCRIPTION
Fixed the problem of shader include path inclusion, added the demo of indirectBuffer synchronization, fixed the problem of hbao using fovy instead of fovy/2, and added the cone culling algorithm for stereo rendering